### PR TITLE
Update workflows to use Node.js 20

### DIFF
--- a/.github/workflows/linux_64_compile.yml
+++ b/.github/workflows/linux_64_compile.yml
@@ -10,7 +10,7 @@ jobs:
     name: runscript
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build for Linux
         run: |
           cd ${{ github.workspace }}/src/jal
@@ -19,7 +19,7 @@ jobs:
           bash ${{ github.workspace }}/src/make_64
 
       - name: Upload binaries to release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: jalv2-x86-64
           path: ${{ github.workspace }}/bin/jalv2-x86-64

--- a/.github/workflows/linux_64_compile.yml
+++ b/.github/workflows/linux_64_compile.yml
@@ -1,7 +1,7 @@
 name: 'Linux Compile 64-bit'
 
 # Compile the JAL compiler for Linux 64-bit and save the produced executable
-# Author: Rob Jansen, copyright (c) 2023..2023, all rights reserverd
+# Author: Rob Jansen, copyright (c) 2023..2023, all rights reserved
 
 on: workflow_dispatch
 

--- a/.github/workflows/mac_64_compile.yml
+++ b/.github/workflows/mac_64_compile.yml
@@ -10,7 +10,7 @@ jobs:
     name: runscript
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build for MAC
         run: |
           cd ${{ github.workspace }}/src/jal
@@ -19,7 +19,7 @@ jobs:
           bash ${{ github.workspace }}/src/make_osx
 
       - name: Upload binaries to release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: jalv2-osx
           path: ${{ github.workspace }}/bin/jalv2-osx

--- a/.github/workflows/mac_64_compile.yml
+++ b/.github/workflows/mac_64_compile.yml
@@ -1,7 +1,7 @@
 name: 'MAC Compile 64-bit'
 
 # Compile the JAL compiler for a MAC and save the produced executable
-# Author: Rob Jansen, copyright (c) 2023..2023, all rights reserverd
+# Author: Rob Jansen, copyright (c) 2023..2023, all rights reserved
 
 on: workflow_dispatch
 

--- a/.github/workflows/windows_64_compile.yml
+++ b/.github/workflows/windows_64_compile.yml
@@ -10,7 +10,7 @@ jobs:
     name: Run batchfile
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Build for Windows
         shell: cmd
         run: |
@@ -18,7 +18,7 @@ jobs:
            cmd /c "make_64_github.bat"
 
       - name: Upload binaries to release
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with: 
           name: jalv2_64.exe
           path: ${{ github.workspace }}\bin\jalv2_64.exe

--- a/.github/workflows/windows_64_compile.yml
+++ b/.github/workflows/windows_64_compile.yml
@@ -1,7 +1,7 @@
 name: 'Windows Compile 64-bit'
 
 # Compile the JAL 64-bit compiler for Windows save the produced executable
-# Author: Rob Jansen, copyright (c) 2023..2023, all rights reserverd
+# Author: Rob Jansen, copyright (c) 2023..2023, all rights reserved
 
 on: workflow_dispatch
 


### PR DESCRIPTION
A quick one to fix the warning

>    Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: ...